### PR TITLE
Added 'secure_ssl_only: false' to example_content.yml config file.

### DIFF
--- a/example_content.yml
+++ b/example_content.yml
@@ -8,3 +8,4 @@ allow_missing_files: true
 allow_adding_terms: true
 media_use: "'Thumbnail Image'|'Original File'"
 log_json: true
+secure_ssl_only: false


### PR DESCRIPTION
As per conversation in Slack, `secure_ssl_only: false` in the workbench config file should avoid SSL certificate errors. There should be no other side effects - all content should load exactly as it did without this setting.

To test, clone this repo and run workbench as usual. The end result should be identical to running workbench without the `secure_ssl_only: false` setting, regardless of whether the current Letsencrypt cert is valid or not.